### PR TITLE
WIP:make use of cmake build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,19 @@
+md build
+cd build
 
-:: Build!
-nmake /f Makefile.vc CFG=release-static RTLIBCFG=static OBJDIR=output
+cmake -LAH -GNinja .. ^
+	-DCMAKE_BUILD_TYPE=Release                              ^
+	-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%           ^
+	-DCMAKE_FIND_ROOT_PATH=%LIBRARY_PREFIX%;%PREFIX%;%BUILD_PREFIX%    ^
+	-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY
+if errorlevel 1 exit 1
+cmake --build .
+if errorlevel 1 exit 1
+cmake --install .
 if errorlevel 1 exit 1
 
-:: Copy the dll's of these dependencies
-copy output\release-static\%ARCH%\bin\cwebp.exe %LIBRARY_PREFIX%\bin\cwebp.exe
-copy output\release-static\%ARCH%\bin\dwebp.exe %LIBRARY_PREFIX%\bin\dwebp.exe
-copy output\release-static\%ARCH%\lib\libwebp.lib %LIBRARY_PREFIX%\lib\libwebp.lib
-copy output\release-static\%ARCH%\lib\libwebp.lib %LIBRARY_PREFIX%\lib\libwebpdecoder.lib
+:: for backwards compatibility with previous make build
+copy %LIBRARY_PREFIX%\lib\webp.lib %LIBRARY_PREFIX%\lib\libwebp.lib
 if errorlevel 1 exit 1
-
-:: Copy header files
-mkdir %LIBRARY_PREFIX%\include\webp\
-copy src\webp\decode.h %LIBRARY_PREFIX%\include\webp\
-copy src\webp\encode.h %LIBRARY_PREFIX%\include\webp\
-copy src\webp\types.h %LIBRARY_PREFIX%\include\webp\
+copy %LIBRARY_PREFIX%\lib\webpdecoder.lib %LIBRARY_PREFIX%\lib\libwebpdecoder.lib
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
+mkdir build
+cd build
+cmake -LAH -GNinja ..                                                  \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX}                                   \
+    -DCMAKE_BUILD_TYPE=Release
 
-# Get an updated config.sub and config.guess
-cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* .
+cmake --build .
 
-# The libwebp build script doesn't pick all the other libraries up on its own
-# (even though it should by using PREFIX), so pass all the necessary parameters
-# for finding other imaging libraries to the configure script.
-./configure --prefix=${PREFIX} --disable-gl --disable-dependency-tracking \
-	--enable-libwebpmux --enable-libwebpdemux --enable-libwebpdecoder \
-	--with-jpeglibdir=${PREFIX}/lib --with-jpegincludedir=${PREFIX}/include \
-	--with-tifflibdir=${PREFIX}/lib --with-tiffincludedir=${PREFIX}/include \
-	--with-giflibdir=${PREFIX}/lib --with-gifincludedir=${PREFIX}/include
-make 
-make check
-make install
+cmake --install .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 mkdir build
 cd build
 cmake -LAH -GNinja ..                                                  \
+    -DBUILD_SHARED_LIBS=ON                                             \
     -DCMAKE_INSTALL_PREFIX=${PREFIX}                                   \
     -DCMAKE_BUILD_TYPE=Release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_subpackage('libwebp', max_pin='x.x') }}
@@ -20,14 +20,13 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - make     # [unix]
-    - libtool  # [unix]
-  host:        # [unix]
-    - jpeg     # [unix]
-    - libpng   # [unix]
-    - libtiff  # [unix]
-    - giflib   # [unix]
-    - libwebp-base {{ version }}
+    - cmake
+    - ninja
+  host:
+    - jpeg # [unix]
+    - libpng
+    - libtiff
+    - giflib
 
 test:
   source_files:


### PR DESCRIPTION
switching to a cmake build has a few advantages:
cmake and ninja can be used more easily across all platforms
the cmake build additionally packages cmake and pkg-config configuration files that makes it easier to use in downstream projects

A downside is that on windows the lib name changes and the build does not
seem to be configurable using CMAKE_LIBRARY_PREFIX_PATH_C. A copy of the library
is performed here to maintain backwards compatibility with the output of the previous
build.

I may need to tweak this to integrate with libwebp-base-feedstock.

