### PR TITLE
[PKG-2864] libwebp 1.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - https://staging.continuum.io/prefect/fs/libwebp-base-feedstock/pr6/619b212

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - https://staging.continuum.io/prefect/fs/libwebp-base-feedstock/pr6/619b212

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.4" %}
+{% set version = "1.3.2" %}
 
 package:
   name: libwebp
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-{{ version }}.tar.gz
-  sha256: 7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df
+  sha256: 2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}
@@ -63,9 +63,11 @@ about:
   license_file: COPYING
   summary: WebP image library
   description: |
-    WebP is a method of lossy and lossless compression that can be used on a large variety of photographic,
-    translucent and graphical images found on the web. The degree of lossy compression is adjustable so a
-    user can choose the trade-off between file size and image quality.
+    WebP is a method of lossy and lossless compression that can be used on a large variety of photographic, 
+    translucent and graphical images found on the web. 
+    The degree of lossy compression is adjustable so a user can choose the trade-off between file size and image quality. 
+    libwebp-base provides the headers and shared libraries. 
+    For cwebp and dwep, binaries install libwebp.
   doc_url: https://developers.google.com/speed/webp/docs/using
   dev_url: https://chromium.googlesource.com/webm/libwebp
 


### PR DESCRIPTION
To fix CVE-2023-4863:

Changelog: https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.3.2/ChangeLog and https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.3.2/NEWS
CMakeLists.txt: https://chromium.googlesource.com/webm/libwebp/+/refs/tags/v1.3.2/CMakeLists.txt

Actions:
1. Reset the build number to `0`
2. Update description

Notes:
- I'm using the [staging channel](https://staging.continuum.io/prefect/fs/libwebp-base-feedstock/pr6/619b212) to pick libwebp-base 1.3.2 up (PR: https://github.com/AnacondaRecipes/libwebp-base-feedstock/pull/6)