### PR TITLE
libwebp 1.3.2: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812ga

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812ga
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 1
+  skip: true  # [s390x]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - giflib {{ giflib }}
     - jpeg {{ jpeg }}
     - libpng {{ libpng }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - libwebp-base {{ version }}.*
   run:
     - libwebp-base {{ version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}
@@ -20,10 +20,10 @@ requirements:
     - gnuconfig            # [unix]
     - make                 # [unix]
   host:
-    - giflib
-    - jpeg
-    - libpng
-    - libtiff
+    - giflib {{ giflib }}
+    - jpeg {{ jpeg }}
+    - libpng {{ libpng }}
+    - libtiff 4.7.0
     - libwebp-base {{ version }}.*
   run:
     - libwebp-base {{ version }}.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 1
-  skip: true  # [s390x]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7592](https://anaconda.atlassian.net/browse/PKG-7592) 
- [Upstream repository](https://chromium.googlesource.com/webm/libwebp)

### Explanation of changes:

- Bump the build number to 1
- Pin host deps

### Notes:

-

[PKG-7592]: https://anaconda.atlassian.net/browse/PKG-7592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ