### PR TITLE
PKG-13552: rebuild libwebp 1.6.0 against giflib 6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}


### PR DESCRIPTION
libwebp 1.6.0 (rebuild)

**Destination channel:** Defaults

### Links

- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) (parent epic — pybind11-v3 ecosystem rebuild)
- Relevant dependency PRs / blockers unblocked:
  - AnacondaRecipes/torchvision-feedstock#43 — osx-arm64 builds blocked by this dep mismatch

### Explanation of changes:

- **Build number 0 -> 1** (no source change).
- **Why:** the aggregate root `conda_build_config.yaml` was updated to `giflib: 6.1` (from `5.2`). The existing pkgs/main libwebp 1.6.0 *_0 builds were compiled against giflib 5.x and declare `giflib >=5.2.2,<5.3.0a0` in run deps. Any downstream consumer building with the current CBC pulls giflib 6.1 from CBC but the resolver also requires libwebp's giflib 5.x — unsatisfiable. Surfaced concretely by torchvision-feedstock #43 on osx-arm64:
  ```
  ├─ giflib =6.1 * is requested and can be installed;
  └─ libwebp >=1.6.0,<2.0a0 * is not installable because it requires
     └─ giflib >=5.2.2,<5.3.0a0
  ```
- **Effect:** the rebuilt libwebp 1.6.0 *_1 pulls giflib 6.1.3 from pkgs/main and declares `giflib >=6.1,<6.2.0a0` (or similar) in run deps, unblocking downstream consumers.
- **Scope:** affects only the run-time giflib pin propagated by libwebp; no source/API changes.

[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ