### PR TITLE
PKG-13234 Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}
@@ -23,7 +23,7 @@ requirements:
     - make                 # [unix]
   host:
     - giflib {{ giflib }}
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libpng {{ libpng }}
     - libtiff {{ libtiff }}
     - libwebp-base {{ version }}.*


### PR DESCRIPTION
libwebp 1.6.0

**Destination channel:**  defaults

### Links

- [PKG-13234](https://anaconda.atlassian.net/browse/PKG-13234) 
- [Upstream repository](https://chromium.googlesource.com/webm/libwebp)
### Explanation of changes:
- New build number
- Replace jpeg to libjpeg-turbo


[PKG-13234]: https://anaconda.atlassian.net/browse/PKG-13234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ